### PR TITLE
Fasttrack was leaking filehandles on non XMP files.

### DIFF
--- a/fasttrack.gemspec
+++ b/fasttrack.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rake', '>= 0.9.2.2'
   gem.add_development_dependency 'mocha', '>= 0.13.0'
+  gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'nokogiri', '>= 1.5.5'
 end

--- a/lib/fasttrack/file.rb
+++ b/lib/fasttrack/file.rb
@@ -49,6 +49,7 @@ module Fasttrack
     # @raise [Fasttrack::FileFormatError] if the file can't have XMP
     #   metadata
     def initialize path, mode="r"
+      @open = false
       @path = Pathname.new(path).expand_path
       if not @path.exist?
         raise Errno::ENOENT, "#{@path} does not exist"
@@ -155,6 +156,7 @@ module Fasttrack
       @open = Exempi.xmp_files_open @file_ptr, @path.to_s, open_option
 
       if not @open
+        Exempi.xmp_files_free(@file_ptr)
         Fasttrack.handle_exempi_failure
       else
         @xmp = Fasttrack::XMP.from_file_pointer @file_ptr
@@ -162,6 +164,5 @@ module Fasttrack
 
       @open
     end
-
   end
 end

--- a/test/filehandle_leak_test.rb
+++ b/test/filehandle_leak_test.rb
@@ -7,12 +7,15 @@ describe Fasttrack::File do
   end
 
   it 'should not leak filehandles' do
-    out, _ = Open3.capture2e("lsof")
-    assert(!out.include?('test.rtf'))
+    exempi_mock = MiniTest::Mock.new
+    exempi_mock.expect(:xmp_files_open, false, [])
+    exempi_mock.expect(:xmp_files_free, true, [])
+    Exempi.stub(:xmp_files_open, false) { exempi_mock.xmp_files_open }
+    Exempi.stub(:xmp_files_free, true) { exempi_mock.xmp_files_free }
+
     assert_raises Exempi::ExempiError do
       Fasttrack::File.new(@test_file)
     end
-    out, _ = Open3.capture2e("lsof")
-    assert(!out.include?('test.rtf'))
+    exempi_mock.verify
   end
 end

--- a/test/filehandle_leak_test.rb
+++ b/test/filehandle_leak_test.rb
@@ -1,0 +1,18 @@
+require 'fasttrack'
+require 'open3'
+
+describe Fasttrack::File do
+  before do
+    @test_file = File.join(__FILE__,'..','data','test.rtf')
+  end
+
+  it 'should not leak filehandles' do
+    out, _ = Open3.capture2e("lsof")
+    assert(!out.include?('test.rtf'))
+    assert_raises Exempi::ExempiError do
+      Fasttrack::File.new(@test_file)
+    end
+    out, _ = Open3.capture2e("lsof")
+    assert(!out.include?('test.rtf'))
+  end
+end


### PR DESCRIPTION
Fasttrack was leaking filehandles when it was trying to read XMP data
from non XMP files. Fixed by releasing the file pointer before handling
the error.
